### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Yann Miecielica
 maintainer=Yann Miecielica
 sentence=An Arduino library similared to Apple UIKit and developed for managing GUI on different kind off display with animations and navigation path.
 paragraph=
-category=UIKit
+category=Display
 url=https://github.com/yMiecie/
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'UIKit' in library Display is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format