### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,10 +23,10 @@ UIViewController	KEYWORD1
 viewDidLoad	KEYWORD2
 viewWillAppear	KEYWORD2
 viewDidAppear	KEYWORD2
-viewWillDesappear KEYWORD2
-viewDidDesappear KEYWORD2
-viewWillUpdate KEYWORD2
-viewDidUpdate KEYWORD2
+viewWillDesappear	KEYWORD2
+viewDidDesappear	KEYWORD2
+viewWillUpdate	KEYWORD2
+viewDidUpdate	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords